### PR TITLE
Minor typo correction in core.proto

### DIFF
--- a/authzed/api/v1/core.proto
+++ b/authzed/api/v1/core.proto
@@ -23,7 +23,7 @@ message Relationship {
   // subject is the subject to which the resource is related, in some manner.
   SubjectReference subject = 3 [ (validate.rules).message.required = true ];
 
-  // optional_caveat is a reference to a the caveat that must be enforced over the relationship
+  // optional_caveat is a reference to the caveat that must be enforced over the relationship
   ContextualizedCaveat optional_caveat = 4 [ (validate.rules).message.required = false ];
 }
 


### PR DESCRIPTION
"a the" -> "the"